### PR TITLE
110 - pyside6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,6 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 10
 
-    runs-on: ${{ matrix.os }}
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
 
       # VTK uses OpenGL 2.0, but the windows Server version used on
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: python -m pip install wheel twine setuptools versioneer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,61 @@ on: push
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-ver: [3.8]
+        experimental: [false]
+        include:
+          - python-ver: 3.9
+            os: ubuntu-latest
+            experimental: true
+          - python-ver: 3.9
+            os: windows-latest
+            experimental: true
+          - python-ver: 3.9
+            os: macos-latest
+            experimental: true
+          - python-ver: '3.10'
+            os: ubuntu-latest
+            experimental: true
+          - python-ver: '3.10'
+            os: macos-latest
+            experimental: true
+          - python-ver: '3.10'
+            os: windows-latest
+            experimental: true
+          - python-ver: 3.11
+            os: ubuntu-latest
+            experimental: true
+          - python-ver: 3.11
+            os: macos-latest
+            experimental: true
+          - python-ver: 3.11
+            os: windows-latest
+            experimental: true
+          - python-ver: 3.12-dev
+            os: ubuntu-latest
+            experimental: true
+          - python-ver: 3.12-dev
+            os: macos-latest
+            experimental: true
+          - python-ver: 3.12-dev
+            os: windows-latest
+            experimental: true
+
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: 10
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-ver }}
 
 
       # VTK uses OpenGL 2.0, but the windows Server version used on
@@ -41,11 +85,26 @@ jobs:
       - name: Run tox on ubuntu using xvfb
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          sudo apt-get install xvfb libxkbcommon-x11-0
-          sudo Xvfb :1 -screen 0 1024x768x24 </dev/null &
-          export DISPLAY=":1"
-          export LD_LIBRARY_PATH=$pythonLocation"/lib/python3.7/site-packages/PySide2/Qt/plugins/platfoms"
-          tox
+          sudo apt-get update
+          sudo apt-get install xvfb
+          sudo apt-get install libegl-dev
+          ## Qt for X11 Requirements> https://doc.qt.io/qt-6/linux-requirements.html
+          sudo apt-get install libfontconfig1-dev libfreetype6-dev
+          sudo apt-get install libx11-dev libx11-xcb-dev
+          sudo apt-get install libxext-dev libxfixes-dev
+          sudo apt-get install libxi-dev libxrender-dev
+          sudo apt-get install libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev
+          sudo apt-get install libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev
+          sudo apt-get install libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev
+          sudo apt-get install libxcb-render-util0-dev libxcb-util-dev libxcb-xinerama0-dev libxcb-xkb-dev
+          sudo apt-get install libxkbcommon-dev libxkbcommon-x11-dev
+          export DISPLAY=:1
+          sudo Xvfb $DISPLAY -screen 0 1024x768x24 </dev/null &
+          export QT_DEBUG_PLUGINS=0
+          export LD_LIBRARY_PATH=$pythonLocation"/lib/python${{ matrix.python-version }}/site-packages/PySide6/Qt/plugins/platforms"
+          coverage erase
+          coverage run -a --source ./sksurgerybard -m pytest -v -s
+          coverage report -m
 
       - name: Run tox on windows/mac
         # Matches the 'o' in 'windows' or 'macos'
@@ -59,13 +118,13 @@ jobs:
           coveralls
 
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/checkout@master
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          pip install -r requirements-dev.txt
  
-      - name: Run tox on ubuntu using xvfb
+      - name: Install dependencies and run tests using xvfb (ubuntu-latest)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
@@ -104,15 +104,20 @@ jobs:
           coverage run -a --source ./sksurgerybard -m pytest -v -s
           coverage report -m
 
-      - name: Run tox on windows/mac
+      - name: Run tests Windows/Mac
         # Matches the 'o' in 'windows' or 'macos'
         if: contains(matrix.os, 'o')
         run: |
-          tox
+          coverage erase
+          coverage run -a --source ./sksurgerybard -m pytest -v -s
+          coverage report -m
+
+      - name: Linting
+        run: |
+          pylint --rcfile=tests/pylintrc sksurgerybard
 
       - name: Run coveralls
         run: |
-          pip install coveralls pyyaml
           coveralls
 
   deploy:

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ Basic Augmented Reality Demo.
    :target: https://github.com/SciKit-Surgery/scikit-surgerybard
    :alt: Logo
 
+|
+
 .. image:: https://github.com/SciKit-Surgery/scikit-surgerybard/workflows/.github/workflows/ci.yml/badge.svg 
    :target: https://github.com/SciKit-Surgery/scikit-surgerybard/actions
    :alt: Travis CI test status
@@ -32,15 +34,22 @@ Basic Augmented Reality Demo.
    :alt: Follow scikit_surgery on twitter
 
 
-Authors: Matt Clarkson, Mian Ahmad, Tom Dowrick, Stephen Thompson
+Author(s): Stephen Thompson and Matt Clarkson;
+Contributor(s): Miguel Xochicale, Thomas Dowrick, and Mian Ahmad.
 
 Basic Augmented Reality Demo (BARD) is part of the `SciKit-Surgery`_ software project, developed at the `Wellcome EPSRC Centre for Interventional and Surgical Sciences`_, part of `University College London (UCL)`_.
 
-The BARD is tested on Python 3.6.
+The BARD is tested on Python 3.8. and may support other Python versions.
 
 
 Developing
 ----------
+
+
+Encountering Problems?
+^^^^^^^^^^^^^^^^^^^^^^
+Please get in touch or raise an `issue`_.
+
 
 Contributing
 ^^^^^^^^^^^^
@@ -77,4 +86,4 @@ Supported by `Wellcome`_ and `EPSRC`_.
 .. _`EPSRC`: https://www.epsrc.ac.uk/
 .. _`contributing guidelines`: https://github.com/SciKit-Surgery/scikit-surgerybard/blob/master/CONTRIBUTING.rst
 .. _`license file`: https://github.com/SciKit-Surgery/scikit-surgerybard/blob/master/LICENSE
-
+.. _`issue`: https://github.com/SciKit-Surgery/scikit-surgerybard/issues/new

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ pytest
 tox
 vtk>=9.2.5
 versioneer
+pyyaml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,11 +9,11 @@ coveralls
 mock
 pyfakefs
 parameterized
-pylint>2.13
+pylint<=2.17.0
 sphinx
 sphinx_rtd_theme
 pyinstaller
 pytest
 tox
-vtk<=9.0.1
+vtk>=9.2.5
 versioneer

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@
 # doc/requirements.rst
 numpy
 glob2
-PySide2<5.15.0
-scikit-surgerycalibration>=0.1.9
-scikit-surgerycore>=0.6.8
-scikit-surgeryutils>=1.2.1
-scikit-surgeryvtk
-scikit-surgeryarucotracker>=0.2.5
-opencv-contrib-python-headless
+pyside6>=6.4.2
+scikit-surgerycalibration>=0.2.1
+scikit-surgerycore>=0.1.7
+scikit-surgeryutils==2.0rc0
+scikit-surgeryvtk==2.0rc0
+scikit-surgeryarucotracker>=0.2.7
+opencv-contrib-python-headless>=4.2.0.32
 #scikit-surgeryspeech>=0.2.0 #uncomment this to use speech interface
 #PocketSphinx # uncomment this to use speech with sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@
 numpy
 glob2
 pyside6>=6.4.2
-scikit-surgerycalibration>=0.2.1
-scikit-surgerycore>=0.1.7
+scikit-surgerycalibration>=0.2.4
+scikit-surgerycore>=0.6.10
 scikit-surgeryutils==2.0rc0
 scikit-surgeryvtk==2.0rc0
-scikit-surgeryarucotracker>=0.2.7
+scikit-surgeryarucotracker>=1.0.1
 opencv-contrib-python-headless>=4.2.0.32
 #scikit-surgeryspeech>=0.2.0 #uncomment this to use speech interface
 #PocketSphinx # uncomment this to use speech with sphinx

--- a/setup.py
+++ b/setup.py
@@ -57,11 +57,11 @@ setup(
         'glob2',
         'pyside6>=6.4.2',
         'opencv-contrib-python-headless>=4.2.0.32',
-        'scikit-surgerycore>=0.6.8',
-        'scikit-surgerycalibration>=0.1.9',
+        'scikit-surgerycore>=0.6.10',
+        'scikit-surgerycalibration>=0.2.4',
         'scikit-surgeryutils==2.0rc0',
         'scikit-surgeryvtk==2.0rc0',
-        'scikit-surgeryarucotracker>=0.2.5',
+        'scikit-surgeryarucotracker>=1.0.1',
     ],
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
 
 
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
 
         'Topic :: Scientific/Engineering :: Information Analysis',
@@ -56,12 +55,12 @@ setup(
     install_requires=[
         'numpy',
         'glob2',
-        'PySide2<5.15.0',
-        'opencv-contrib-python-headless',
+        'pyside6>=6.4.2',
+        'opencv-contrib-python-headless>=4.2.0.32',
         'scikit-surgerycore>=0.6.8',
         'scikit-surgerycalibration>=0.1.9',
-        'scikit-surgeryutils>=1.2.1',
-        'scikit-surgeryvtk',
+        'scikit-surgeryutils==2.0rc0',
+        'scikit-surgeryvtk==2.0rc0',
         'scikit-surgeryarucotracker>=0.2.5',
     ],
 

--- a/sksurgerybard/interaction/speech_interaction.py
+++ b/sksurgerybard/interaction/speech_interaction.py
@@ -5,7 +5,7 @@ requirements.txt"""
 
 #pylint:disable=super-with-arguments, raise-missing-from
 
-from PySide2.QtCore import QObject, Slot, QThread
+from PySide6.QtCore import QObject, Slot, QThread # pylint:disable=no-name-in-module
 try:
     from sksurgeryspeech.algorithms.voice_recognition_service import \
         VoiceRecognitionService #pylint: disable=import-error

--- a/sksurgerybard/ui/sksurgerybard_command_app.py
+++ b/sksurgerybard/ui/sksurgerybard_command_app.py
@@ -2,7 +2,7 @@
 
 """ Demo app, to show OpenCV video and PySide2 widgets together."""
 
-from PySide2.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication # pylint:disable=no-name-in-module
 from sksurgerycore.configuration.configuration_manager import \
         ConfigurationManager
 from sksurgerybard.widgets.bard_overlay_app import BARDOverlayApp

--- a/tests/interaction/test_speech_interation.py
+++ b/tests/interaction/test_speech_interation.py
@@ -4,7 +4,7 @@ from time import sleep
 import sys
 import pytest
 
-from PySide2.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication # pylint:disable=no-name-in-module
 
 
 try:

--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -340,4 +340,4 @@ analyse-fallback-blocks=no
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/tests/test_utilities/sksurgeryspeech/algorithms/voice_recognition_service.py
+++ b/tests/test_utilities/sksurgeryspeech/algorithms/voice_recognition_service.py
@@ -1,4 +1,4 @@
-from PySide2.QtCore import QObject, Signal, Slot, QThread, QTimer
+from PySide6.QtCore import QObject, Signal, Slot, QThread, QTimer
 
 class VoiceRecognitionService(QObject):
     """A fake Voice recognition service, to enable us to do some

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands = versioneer install
 basepython=python3.8
 deps=pylint
      {[testenv]deps}
-commands=pylint --rcfile=tests/pylintrc --extension-pkg-whitelist=PySide2,vtk,cv2, sksurgerybard tests
+commands=pylint --rcfile=tests/pylintrc --extension-pkg-whitelist=PySide6,vtk,cv2, sksurgerybard tests
 
 [testenv:docs]
 basepython=python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py37,lint
+envlist = py38,lint
 skipsdist = True
 requires = setuptools >= 47.1
 
 [travis]
 python =
-  3.7: py37, docs, lint
+  3.8: py38, docs, lint
 
 [testenv]
 passenv = *
@@ -21,22 +21,22 @@ commands = versioneer install
            coverage report -m
 
 [testenv:lint]
-basepython=python3.7
+basepython=python3.8
 deps=pylint
      {[testenv]deps}
 commands=pylint --rcfile=tests/pylintrc --extension-pkg-whitelist=PySide2,vtk,cv2, sksurgerybard tests
 
 [testenv:docs]
-basepython=python3.7
+basepython=python3.8
 changedir = doc
 commands = sphinx-build -M html . build
 
 [testenv:installer]
-basepython=python3.7
+basepython=python3.8
 commands=python -c "print('Installer not needed for this project.')"
 
 [testenv:pip3]
-basepython=python3.7
+basepython=python3.8
 changedir=pip_test
 skip_install=True
 commands = pip install {posargs}


### PR DESCRIPTION
This PR solves #110 

### General summary: 
* [x] 36 passed test in local ubuntu2204 machine (tox>py38OK,lintOK); refactors library with pyside6 dependency; fixs version requirements
* [x] removes py3.7 due to end-of-life on 2023-06-27 https://devguide.python.org/versions/
* [x] ci.yml: adds python versions 3.9, 3.10, 3.11, 3.12-dev
* [x] adds python-version: 3.8 for python version for deploy
* [x] Refactor ci.yml with linting, coverage and other missing bits for Qt for X11
* [x] Remote unit test for python versions 3.9, 3.10, 3.11, 3.12-dev and ubuntu-latest, mac-latest and windows-latest has been sorted out
* [x] Shall we use [v1.0.2alpha](https://github.com/SciKit-Surgery/scikit-surgeryarucotracker/releases/tag/v1.0.2alpha)? Steve mentioned that it is better to use the latest versions.
* [x] Update main README
* [x] https://github.com/SciKit-Surgery/scikit-surgerybard/issues/59

### Unit test summary from https://github.com/SciKit-Surgery/scikit-surgerybard/actions/runs/4566120524
* Local machine ubuntu-22.04: 36 passed
* Remote ubuntu-22.04: 36 passed
* Remote mac-latests: 36 passed 
* Remote windows-latests: 36 passed 